### PR TITLE
fixed crash when dumping unexpected data

### DIFF
--- a/luadump.lua
+++ b/luadump.lua
@@ -290,8 +290,12 @@ local function dump(printFn)
                 end
             end,
             ["thread"] = function() return "" end
-        }
-        return callback[type(node)](node)
+        }        
+        if callback[type(node)] then
+            return callback[type(node)](node)
+        else
+            return "<unknown type>"
+        end        
     end
     return printLua
 end


### PR DESCRIPTION
This actually happened when trying to dump the params of a builder.apply event in TPF2 when building a street cargo station (large one). Feel free to investigate the actual reason. 

PS: L63 sortKeys is an undefined global. Didn't understand the intention, so I have no fix. But maybe it's related.